### PR TITLE
Fix default return for timeline action hook

### DIFF
--- a/inc/link.class.php
+++ b/inc/link.class.php
@@ -73,6 +73,7 @@ class PluginOnetimesecretLink extends CommonDBTM {
 				
 				break;
 		}
+		return [];
 	}
 
 	function showForm($ID, array $params=[]) {


### PR DESCRIPTION
Although not specified in the documentation, the way this hook is handled, the function must always return an array.
See glpi-project/glpi#11880.